### PR TITLE
Support parallel build of rocksdb

### DIFF
--- a/scripts/build_script.sh
+++ b/scripts/build_script.sh
@@ -17,6 +17,7 @@ echo "cache dir: $HOST_CACHE_DIR"
 mkdir -p $HOST_CACHE_DIR
 
 cibuildwheel \
+    --jobs ${PYREX_JOBS:-1}
 	--platform linux \
 	--config-file $TOML_FILE \
 	--output-dir "wheelhouse-RocksDB${ROCKSDB_VERSION}"


### PR DESCRIPTION
Adding support for increasing the number of cores utilized during rocksdb build from 1 to the value set in PYREX_JOBS environment variable, defaults to 1 if PYREX_JOBS is not set.

Needs testing, testing in progress. 